### PR TITLE
Feature request: extend options for pimatic-mail plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ pimatic mail plugin
 =======================
 
 
-Send mails from pimatic actions. It uses [nodemailer](https://www.npmjs.org/package/nodemailer) and so supports all common mail transports.
+Provides an action handler to send mails from pimatic rules. It uses 
+ [nodemailer v0.7](https://github.com/andris9/Nodemailer/blob/0.7/README.md) which supports all common mail transports.
 
 Configuration
 -------------
@@ -21,20 +22,33 @@ You can load the backend by editing your `config.json` to include:
       "to": "gmail.user@gmail.com"
     }
 
-in the `plugins` section. For all configuration options see [mail-config-schema](mail-config-schema.html)
+in the `plugins` section. For all configuration options see [mail-config-schema](mail-config-schema.html). The 
+ transport options are transport dependent and listed at 
+ [nodemailer v0.7](https://github.com/andris9/Nodemailer/blob/0.7/README.md),
 
-The transport options are transport depenedent and listed at [nodemailer](https://www.npmjs.org/package/nodemailer),
+Usage
+-----
 
-Currently you can send mail message via action handler within rules.
+Currently, you can send mail messages as part of rule actions. The "send mail" action supports the following 
+modifiers:
 
-Example:
---------
+* **to**: the mail recipient's address
+* **from**: the mail sender's address
+* **text**: an ASCII test string to be used as e-mail body text. If, both, **text** and **html** modifiers are 
+ absent, the default text will be used as defined by the the plugin configuration.
+* **html**: a HTML text string to be used as e-mail HTML body text. Id, both, **text** and **html** modifiers are 
+ present, an e-mail with a multi-part body will be generated containing the plain text and the HTML text.
+* **file**: a path to a file which will be attached to the e-mail. 
+
+
+Example
+-------
 
     IF it is 08:00 THEN send mail to:"gmail.user@gmail.com" subject:"Good morning!" text:"Good morning Dave!"
 
+Credits
+-------
 
-Credits:
---------
-
-<div>Icon made by <a href="http://www.unocha.org" title="OCHA">OCHA</a> is licensed under <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0">CC BY 3.0</a></div>
+<div>Icon made by <a href="http://www.unocha.org" title="OCHA">OCHA</a> is licensed under 
+ <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0">CC BY 3.0</a></div>
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If your mail service provider is not on nodemailer's list of [well known service
   with error 550 which is provides a measure against misuse of mail addresses. You should set 
   the 'from' address as part of the plugin configuration.
 
+Example:
 
     {
       "plugin": "mail",
@@ -79,8 +80,8 @@ modifiers:
 Generally, each modifier can only by applied once per mail action. For **to:** and **file:** modifiers, multiple 
  occurrences are supported.
 
-Example
--------
+Example Rule
+------------
 
     IF it is 08:00 THEN send mail to:"gmail.user@gmail.com" subject:"Good morning!" text:"Good morning Dave!"
     

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Usage
 Currently, you can send mail messages as part of rule actions. The "send mail" action supports the following 
 modifiers:
 
-* **to**: the mail recipient's address
-* **from**: the mail sender's address
-* **text**: an ASCII test string to be used as e-mail body text. If, both, **text** and **html** modifiers are 
- absent, the default text will be used as defined by the the plugin configuration.
-* **html**: a HTML text string to be used as e-mail HTML body text. Id, both, **text** and **html** modifiers are 
- present, an e-mail with a multi-part body will be generated containing the plain text and the HTML text.
-* **file**: a path to a file which will be attached to the e-mail. 
+* **to**: The mail recipient's address
+* **from**: The mail sender's address
+* **text**: An Unicode string containing the plaintext version of the message body. If, both, **text** and **html** modifiers are 
+ absent, the default text will be used as defined by the plugin configuration
+* **html**: An Unicode string containing the HTML version of the message body. If, both, **text** and **html** modifiers are 
+ present, an e-mail with a multi-part body will be generated containing the plain text and the HTML text
+* **file**: A path to a file which will be attached to the mail
 
 
 Example

--- a/README.md
+++ b/README.md
@@ -24,7 +24,39 @@ You can load the backend by editing your `config.json` to include:
 
 in the `plugins` section. For all configuration options see [mail-config-schema](mail-config-schema.html). The 
  transport options are transport dependent and listed at 
- [nodemailer v0.7](https://github.com/andris9/Nodemailer/blob/0.7/README.md),
+ [nodemailer v0.7](https://github.com/andris9/Nodemailer/blob/0.7/README.md).
+ 
+Advanced Configuration Example for GMX
+--------------------------------------
+
+If your mail service provider is not on nodemailer's list of [well known services]
+ (https://github.com/andris9/Nodemailer/blob/0.7/README.md#well-known-services-for-smtp) an advanced transport 
+ configuration is required. In the following an example configuration for GMX is provide which deals 
+ with some issues which may also apply to other mail service providers:
+* The GMX SMTP mailer is picky about encryption ciphers used and, thus, the cipher suite used for pimatic
+  must be set to 'SSLv3'
+* The "from" address must be set explicitly to your mailbox address. Otherwise, the mail will be rejected 
+  with error 550 which is provides a measure against misuse of mail addresses. You should set 
+  the 'from' address as part of the plugin configuration.
+
+    {
+      "plugin": "mail",
+      "transport": "SMTP",
+      "transportOptions": {
+        "host": "mail.gmx.com",
+        "port": 587,
+        "tls": {
+          "ciphers": "SSLv3"
+        },
+        "auth": {
+          "user": "Zaphod.Beeblebrox@gmx.de",
+          "pass": "TopSecret"
+        },
+        "maxConnections": 5
+      },
+      "from": "Zaphod.Beeblebrox@gmx.de"
+    }	
+
 
 Usage
 -----
@@ -32,14 +64,16 @@ Usage
 Currently, you can send mail messages as part of rule actions. The "send mail" action supports the following 
 modifiers:
 
-* **to**: The mail recipient's address
-* **from**: The mail sender's address
-* **text**: An Unicode string containing the plaintext version of the message body. If, both, **text** and **html** modifiers are 
+* **to:** The mail recipient's address
+* **from:** The mail sender's address
+* **text:** An Unicode string containing the plaintext version of the message body. If, both, **text** and **html** modifiers are 
  absent, the default text will be used as defined by the plugin configuration
-* **html**: An Unicode string containing the HTML version of the message body. If, both, **text** and **html** modifiers are 
+* **html:** An Unicode string containing the HTML version of the message body. If, both, **text** and **html** modifiers are 
  present, an e-mail with a multi-part body will be generated containing the plain text and the HTML text
-* **file**: A path to a file which will be attached to the mail
+* **file:** A path to a file which will be attached to the mail
 
+Generally, each modifier can only by applied once per rule. For **to:** and **file:** modifiers, multiple occurrences 
+ are supported.
 
 Example
 -------

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ Advanced Configuration Example for GMX
 
 If your mail service provider is not on nodemailer's list of [well known services]
  (https://github.com/andris9/Nodemailer/blob/0.7/README.md#well-known-services-for-smtp) an advanced transport 
- configuration is required. In the following an example configuration for GMX is provided. This configuration deals 
+ configuration is required. Below, an example configuration for GMX is provided. This configuration deals 
  with some issues which may also apply to other mail service providers:
+ 
 * Host and Port of the mail service. You can obtain this information from your mail service provider.
 * The GMX SMTP mailer is picky about encryption ciphers used and, thus, the cipher suite used for pimatic
   must be set to 'SSLv3'
 * The "from" address must be set explicitly to your mailbox address. Otherwise, the mail will be rejected 
   with error 550 which is provides a measure against misuse of mail addresses. You should set 
   the 'from' address as part of the plugin configuration.
+
 
     {
       "plugin": "mail",

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Advanced Configuration Example for GMX
 
 If your mail service provider is not on nodemailer's list of [well known services]
  (https://github.com/andris9/Nodemailer/blob/0.7/README.md#well-known-services-for-smtp) an advanced transport 
- configuration is required. In the following an example configuration for GMX is provide which deals 
+ configuration is required. In the following an example configuration for GMX is provided. This configuration deals 
  with some issues which may also apply to other mail service providers:
+* Host and Port of the mail service. You can obtain this information from your mail service provider.
 * The GMX SMTP mailer is picky about encryption ciphers used and, thus, the cipher suite used for pimatic
   must be set to 'SSLv3'
 * The "from" address must be set explicitly to your mailbox address. Otherwise, the mail will be rejected 
@@ -61,24 +62,26 @@ If your mail service provider is not on nodemailer's list of [well known service
 Usage
 -----
 
-Currently, you can send mail messages as part of rule actions. The "send mail" action supports the following 
+You can send mail messages as part of rule actions. The "send mail" action supports the following 
 modifiers:
 
 * **to:** The mail recipient's address
 * **from:** The mail sender's address
-* **text:** An Unicode string containing the plaintext version of the message body. If, both, **text** and **html** modifiers are 
- absent, the default text will be used as defined by the plugin configuration
-* **html:** An Unicode string containing the HTML version of the message body. If, both, **text** and **html** modifiers are 
- present, an e-mail with a multi-part body will be generated containing the plain text and the HTML text
+* **text:** An Unicode string containing the plaintext version of the message body. If, both, **text** 
+ and **html** modifiers are absent, the default text will be used as defined by the plugin configuration
+* **html:** An Unicode string containing the HTML version of the message body. If, both, **text** 
+ and **html** modifiers are present, an e-mail with a multi-part body will be generated containing the 
+ plain text and the HTML text
 * **file:** A path to a file which will be attached to the mail
 
-Generally, each modifier can only by applied once per rule. For **to:** and **file:** modifiers, multiple occurrences 
- are supported.
+Generally, each modifier can only by applied once per mail action. For **to:** and **file:** modifiers, multiple 
+ occurrences are supported.
 
 Example
 -------
 
     IF it is 08:00 THEN send mail to:"gmail.user@gmail.com" subject:"Good morning!" text:"Good morning Dave!"
+    
 
 Credits
 -------

--- a/mail.coffee
+++ b/mail.coffee
@@ -58,18 +58,22 @@ module.exports = (env) ->
       condition = true
       index = 0
       while condition
-        next = m.match(mailOptionsPatterns).matchStringWithVars( (m, tokens) =>
-          matchedOptionPattern = m.elements[m.elements.length - 2].match;
-          opt = matchedOptionPattern.replace(/^[\s\uFEFF\xA0]+|[\:]+$|[\s\uFEFF\xA0]+$/g, '')
-          optionsSet.push opt
-          unless opt is "file" or opt is "to"
-            optionsTokens[opt] = tokens
-            # remove matched pattern from mailOptionsPatterns as all options except file may only occur once
-            mailOptionsPatterns = mailOptionsPatterns.filter (item) -> item isnt matchedOptionPattern
-          else
-            optionsTokens[opt + index++] = tokens
+        next = null
+        m.match(mailOptionsPatterns, (m, matchedOptionPattern) =>
+          m.matchStringWithVars( (m, tokens) =>
+            opt = matchedOptionPattern.replace(/^[\s\uFEFF\xA0]+|[\:]+$|[\s\uFEFF\xA0]+$/g, '')
+            optionsSet.push opt
+            unless opt is "file" or opt is "to"
+              optionsTokens[opt] = tokens
+              # remove matched pattern from mailOptionsPatterns as all options except file may only occur once
+              mailOptionsPatterns = mailOptionsPatterns.filter (item) -> item isnt matchedOptionPattern
+            else
+              # we could make this an array...
+              optionsTokens[opt + index++] = tokens
+            next = m
+          )
         )
-        condition = next.hadMatch()
+        condition = next?
         m = next if condition
 
       if m.hadMatch()

--- a/mail.coffee
+++ b/mail.coffee
@@ -61,7 +61,7 @@ module.exports = (env) ->
         next = null
         m.match(mailOptionsPatterns, (m, matchedOptionPattern) =>
           m.matchStringWithVars( (m, tokens) =>
-            opt = matchedOptionPattern.replace(/^[\s\uFEFF\xA0]+|[\:]+$|[\s\uFEFF\xA0]+$/g, '')
+            opt = matchedOptionPattern.replace(/^\s+|\:+$/g, '')
             optionsSet.push opt
             unless opt is "file" or opt is "to"
               optionsTokens[opt] = tokens

--- a/mail.coffee
+++ b/mail.coffee
@@ -20,7 +20,7 @@ module.exports = (env) ->
 
       mailTransport = nodemailer.createTransport(
         config.transport
-        config.transportOptions
+        _.clone(config.transportOptions, true)
       )
       Promise.promisifyAll(mailTransport)
 

--- a/mail.coffee
+++ b/mail.coffee
@@ -53,20 +53,19 @@ module.exports = (env) ->
       # may occur multiple times as it is the case for "to" and "file"
       mailOptionsPatterns = []
       for key in @mailOptionKeys
-        mailOptionsPatterns.push " #{key}:"
+        mailOptionsPatterns.push [key, " #{key}:"]
         
       condition = true
       index = 0
       while condition
         next = null
-        m.match(mailOptionsPatterns, (m, matchedOptionPattern) =>
+        m.match(mailOptionsPatterns, (m, opt) =>
           m.matchStringWithVars( (m, tokens) =>
-            opt = matchedOptionPattern.replace(/^\s+|\:+$/g, '')
             optionsSet.push opt
             unless opt is "file" or opt is "to"
               optionsTokens[opt] = tokens
               # remove matched pattern from mailOptionsPatterns as all options except file may only occur once
-              mailOptionsPatterns = mailOptionsPatterns.filter (item) -> item isnt matchedOptionPattern
+              mailOptionsPatterns = mailOptionsPatterns.filter (item) -> item[0] isnt opt
             else
               # we could make this an array...
               optionsTokens[opt + index++] = tokens

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "icon": "icon.svg",
   "configSchema": "mail-config-schema.coffee",
   "dependencies": {
-    "nodemailer": "~0.6.2"
+    "nodemailer": "~0.7.1"
   },
   "keywords": [
     "pimatic",


### PR DESCRIPTION
This pull request implements the following:
- update to nodemailer0.7.1
- added "file" modifier which allows for attaching a file
- added "html" modifier which allows for adding a HTML text body.
- "to" and "file" modifiers may be used multiple times to defined mutiple recipinet and/or multiple attachments
- now, modifiers can be provided in arbritary order
- added configuration example for GMX

See also: http://forum.pimatic.org/topic/797/extend-options-for-pimatic-mail-plugin
